### PR TITLE
Add more point defects, and some other enhancements

### DIFF
--- a/scripts/run-all.py
+++ b/scripts/run-all.py
@@ -2,25 +2,31 @@
 
 import os
 import sys
+import subprocess
 import glob
 import re
 import json
 import argparse
 import itertools
+import shlex
 
 my_path=os.path.dirname(os.path.realpath(__file__))
 
 parser = argparse.ArgumentParser(description='Run all tests on all models.  Default command line options in dict of lists in "default_run_opts.json", keys are "global" or regexps matching model names')
-parser.add_argument('--test_set', '-s', action='store', help='label for tests directories',required=True)
+parser.add_argument('--test_set', '-s', nargs='+', help='label(s) for tests directories', required=True)
 parser.add_argument('--models', '-m', action='store', nargs='+', type=str, help='models to include')
 parser.add_argument('--tests', '-t', action='store', nargs='+', type=str, help='tests to include')
 parser.add_argument('--omit-tests', '-o', action='store', nargs='+', type=str, help='tests to omit')
 parser.add_argument('--force', '-f', action='store_true', help='force rerunning of tests')
 parser.add_argument('--bugs', '-b', action='store_true', help='use bugs to generate job scripts')
+parser.add_argument('--np', '-n', help='override number of processor when using bugs')
+parser.add_argument('--bugs_host', '-H', help='host to force bugs to use',
+                    default=re.sub('[0-9]*$', '', os.environ['HOSTNAME'].split('.')[0]))
 parser.add_argument('--MPI', '-M', action='store_true', help='use MPI')
 parser.add_argument('--OpenMP', '-O', action='store_true', help='use OpenMP')
 parser.add_argument('--base_model', '-B', action='store', type=str, help='model to use as initial config for tests where it is enabled')
-parser.add_argument('--models_path', '-P', action='store', type=str, help='path to models directory', default=os.path.join(os.getcwd(),'../models'))
+parser.add_argument('--models_path', '-MP', action='store', type=str, help='path to models directory', default=os.path.join(os.getcwd(),'../models'))
+parser.add_argument('--tests_path', '-TP', action='store', type=str, help='path to tests directory (above test_set)', default=os.path.join(my_path,'../tests'))
 parser.add_argument('--n_procs', '-N', action='store', type=int, help='number of processors to round to', default=16)
 
 global_default_run_opts = []
@@ -34,11 +40,9 @@ if os.path.exists("default_run_opts.json"):
 
 args = parser.parse_args(sys.argv[1:] + global_default_run_opts)
 
-tests_path = os.path.join(my_path,"..","tests",args.test_set)
 
 models = None
 tests = None
-omittests = None
 if args.models is not None:
     print("Models asked for: ", args.models)
     models = list(itertools.chain.from_iterable([ glob.glob(os.path.join(args.models_path, d, 'model.py')) for d in args.models ]))
@@ -48,18 +52,31 @@ print("Models path: ", args.models_path)
 print("Models found: ", models)
 models = [ os.path.split(d)[0] for d in models ]
 
-if args.tests is not None:
-    tests = list(itertools.chain.from_iterable([ glob.glob(os.path.join(tests_path, d, 'test.py')) for d in args.tests ]))
-else:
-    tests = glob.glob(os.path.join(tests_path, '*', 'test.py'))
-tests = [ os.path.split(t)[0] for t in tests ]
-if args.omit_tests is not None:
-    for omit_test in list(itertools.chain.from_iterable([ glob.glob(os.path.join(tests_path, d)) for d in args.omit_tests ])):
-        if omit_test in tests:
-            tests.remove(omit_test)
-        else:
-            sys.stderr.write("WARNING: omitted test %s not in list of tests\n" % omit_test)
+def clean_path(p):
+    if p.startswith(os.environ['HOME']):
+        p_home = '"$HOME"'
+        p_rest = p.replace(os.environ['HOME'], '')
+    else:
+        p_home = ''
+        p_rest = p
+    return p_home+shlex.quote(p_rest)
 
+tests = []
+for test_set in args.test_set:
+    tests_path = os.path.join(args.tests_path,test_set)
+
+    if args.tests is not None:
+        tests_t = list(itertools.chain.from_iterable([ glob.glob(os.path.join(tests_path, d, 'test.py')) for d in args.tests ]))
+    else:
+        tests_t = glob.glob(os.path.join(tests_path, '*', 'test.py'))
+    tests_t = [ os.path.split(t)[0] for t in tests_t ]
+    if args.omit_tests is not None:
+        for omit_test in list(itertools.chain.from_iterable([ glob.glob(os.path.join(tests_path, d)) for d in args.omit_tests ])):
+            if omit_test in tests_t:
+                tests_t.remove(omit_test)
+            else:
+                sys.stderr.write("WARNING: omitted test %s not in list of tests\n" % omit_test)
+    tests.extend([(test, test_set) for test in tests_t])
 
 force = args.force
 bugs = args.bugs
@@ -73,7 +90,7 @@ for model in models:
     model_name = os.path.split(model)[-1]
 
     model_default_run_opts = []
-    if default_run_opts is not None: 
+    if default_run_opts is not None:
         for m in default_run_opts:
             if re.search(m, model_name) is not None:
                 model_default_run_opts = default_run_opts[m]
@@ -81,7 +98,7 @@ for model in models:
 
     args = parser.parse_args(sys.argv[1:] + model_default_run_opts + global_default_run_opts)
 
-    for test in tests:
+    for test, test_set in tests:
         test_name = os.path.split(test)[-1]
         try:
             fp = open(model+"/COMPUTATIONAL_COST")
@@ -93,32 +110,47 @@ for model in models:
             test_cost = float(fp.readline().strip())
         except:
             test_cost = 1.0
-        np=int(round(int(test_cost*model_cost*args.n_procs)/float(args.n_procs)))*args.n_procs
-        if np < args.n_procs:
-            np = args.n_procs
 
-        cmd_args = '{0} {1} {2} --test_set {3}'.format(run_model_test, "'"+os.path.join(args.models_path,model_name)+"'", test_name, args.test_set)
-        if force:
-            cmd_args += ' -force'
-        if args.base_model is not None:
-            cmd_args += ' --base_model '+args.base_model
+        if args.np is None:
+            np=int(round(int(test_cost*model_cost*args.n_procs)/float(args.n_procs)))*args.n_procs
+            if np < args.n_procs:
+                np = args.n_procs
+        else:
+            np = args.np
 
         if args.bugs:
-            ident_string= '{0}_{1}_{2}'.format(args.test_set, model_name, test_name)
+            # only clean for bugs, which will feed path into shell
+            cmd_args = [ clean_path(run_model_test), clean_path(os.path.join(args.models_path,model_name)),
+                         clean_path(test) ]
+        else:
+            cmd_args = [ run_model_test, os.path.join(args.models_path,model_name), test ]
+        cmd_args += [ '--system_label', test_set ]
+
+        if force:
+            cmd_args += [ '-force' ]
+        if args.base_model is not None:
+            cmd_args += [ '--base_model', args.base_model ]
+
+        if args.bugs:
+            ident_string= '{0}_{1}_{2}'.format(test_set, model_name, test_name)
+            cmd = ['bugs', '-exec=python' ]
             if args.MPI:
                 bugs_script='test.bugs_script_mpi'
-                mpi_cmd=''
             else:
-                mpi_cmd='-no_mpirun'
+                cmd += ['-no_mpirun']
                 bugs_script='test.bugs_script'
             if args.OpenMP:
                 bugs_script+='_openmp'
-            bugs_script += '.'+os.environ['HOSTNAME'].split('.')[0]
-            cmd=('env REDIRECT_IO="'+cmd_args+'" bugs -exec=python '+mpi_cmd+' -time=96h -np='+('%d' % np)+' -script='+bugs_script+
-                 ' -name='+ident_string+' -fileroot='+ident_string+' -in_cwd -output=job.'+ident_string)
+            bugs_script += '.'+args.bugs_host
+            cmd += [ '-time=96h', f'-np={np}', f'-script={bugs_script}', f'-host={args.bugs_host}', f'-name={ident_string}',
+                     f'-fileroot={ident_string}', '-in_cwd', f'-output=job.{ident_string}' ]
+
+            cmd_env = os.environ.copy()
+            cmd_env['REDIRECT_IO'] = ' '.join(cmd_args)
         else:
-            cmd="python "+cmd_args
+            cmd = ['python'] + cmd_args
+            cmd_env = None
         print(cmd)
         # TODO: convert this to using subprocess.run()
-        os.system(cmd)
-        
+        subprocess.run(cmd, env=cmd_env)
+

--- a/scripts/run-model-test.py
+++ b/scripts/run-model-test.py
@@ -37,6 +37,7 @@ parser.add_argument('--system_label','-l', type=str, action='store', help='label
 parser.add_argument('--force','-f', action='store_true', help='force rerunning of test')
 parser.add_argument('--base_model','-B', type=str, action='store', help='optional base model to start from')
 parser.add_argument('--no_redirect_io','-N', action='store_true', help='do not redirect io')
+parser.add_argument('--no_append_log', dest='append_log', action='store_false', help='overwrite log (.txt) file, rather than appending')
 args = parser.parse_args()
 
 model_path = os.path.split(args.model)[0]
@@ -91,11 +92,15 @@ sys.path.insert(0, test_dir)
 if not args.no_redirect_io:
     _stdout, _stderr = sys.stdout, sys.stderr
     if do_io:
-        log = open(os.path.join('..',run_root+'.txt'), 'w', 1)
+        if args.append_log:
+            log = open(os.path.join('..',run_root+'.txt'), 'a', 1)
+        else:
+            log = open(os.path.join('..',run_root+'.txt'), 'w', 1)
         sys.stdout, sys.stderr = log, log
     else:
         sys.stdout = open(os.devnull, "w")
         sys.stderr = open(os.devnull, "w")
+sys.stdout.write('\n###### START RUN '+time.ctime()+' ######\n')
 
 import logging
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)

--- a/scripts/run-model-test.py
+++ b/scripts/run-model-test.py
@@ -33,7 +33,7 @@ except:
 parser = argparse.ArgumentParser(description='Run a particular model-test combination')
 parser.add_argument('model', type=str, action='store', help='model name')
 parser.add_argument('test', type=str, action='store', help='test name')
-parser.add_argument('--test_set','-s', type=str, action='store', help='label for tests directory', required=True)
+parser.add_argument('--system_label','-l', type=str, action='store', help='label for tests directory', default='')
 parser.add_argument('--force','-f', action='store_true', help='force rerunning of test')
 parser.add_argument('--base_model','-B', type=str, action='store', help='optional base model to start from')
 parser.add_argument('--no_redirect_io','-N', action='store_true', help='do not redirect io')
@@ -43,7 +43,12 @@ model_path = os.path.split(args.model)[0]
 if len(model_path) == 0:
     model_path = os.path.join("..","..","models")
 model_name = os.path.split(args.model)[1]
-test_name = args.test
+
+test_path = os.path.split(args.test)[0]
+if len(test_path) == 0:
+    test_path = os.path.join("..","..","tests")
+test_name = os.path.split(args.test)[1]
+
 force = args.force
 
 my_path = os.path.split(os.path.realpath(__file__))[0]
@@ -59,7 +64,7 @@ import utilities
 utilities.model_name = model_name
 utilities.base_model_name = args.base_model
 utilities.test_name = test_name
-utilities.system_label = args.test_set
+utilities.system_label = args.system_label
 
 run_root = utilities.model_test_root()
 dir_name = "run_"+run_root # maybe a different name?
@@ -77,7 +82,7 @@ if not force and os.path.isfile(json_file_name) and os.path.getsize(json_file_na
     sys.exit(0)
 
 model_dir = os.path.join(model_path, model_name)
-test_dir = os.path.join(my_path, '..', 'tests', args.test_set, test_name)
+test_dir = os.path.join(test_path, test_name)
 
 ## sys.path.insert(0, share_dir)
 sys.path.insert(0, model_dir)

--- a/share/antisite.py
+++ b/share/antisite.py
@@ -1,0 +1,91 @@
+import ase.io, os.path
+from utilities import relax_config, run_root, rescale_to_relaxed_bulk, evaluate
+import ase.build
+import numpy as np
+import spglib
+
+def do_one_antisite_pair(bulk_supercell, bulk_supercell_pe, i1, i2, tol=1.0e-2):
+    assert bulk_supercell.numbers[i1] != bulk_supercell.numbers[i2]
+
+    # do unrelaxed (without perturbations)
+    antisite = bulk_supercell.copy()
+    Z1, Z2 = antisite.numbers[[i1, i2]]
+    antisite.numbers[i1] = Z2
+    antisite.numbers[i2] = Z1
+
+    label = "ind_%d_Z_%d_ind_%d_Z_%d" % (i1, Z1, i2, Z2)
+    unrelaxed_filename=run_root+"-%s-unrelaxed.xyz" % label
+    ase.io.write(os.path.join("..", unrelaxed_filename), antisite, format='extxyz')
+    evaluate(antisite)
+    unrelaxed_antisite_pe = antisite.get_potential_energy()
+
+    antisite = relax_config(antisite, relax_pos=True, relax_cell=False, tol=tol, save_traj=True,
+        config_label=label, from_base_model=True, save_config=True, try_restart=True)
+    relaxed_filename=run_root+"-%s-relaxed.xyz" % label
+    ase.io.write(os.path.join("..", relaxed_filename), antisite, format='extxyz')
+
+    # already has calculator from relax_configs
+    antisite_pe = antisite.get_potential_energy()
+    Ef0 = unrelaxed_antisite_pe - bulk_supercell_pe
+    Ef = antisite_pe - bulk_supercell_pe
+    print("got antisite", label, "cell energy", antisite_pe, "n_atoms", len(antisite))
+    print("got bulk energy", bulk_supercell_pe)
+    return ( label, unrelaxed_filename, Ef0, relaxed_filename, Ef, Z1, Z2 )
+
+def do_farthest_inequiv_pairs(test_dir, tol=1.0e-2):
+    print("doing do_farthest_antisite_pairs")
+    bulk_supercell = ase.io.read(os.path.join(test_dir, "bulk_supercell.xyz"), format="extxyz")
+    print("got bulk_supercell ", len(bulk_supercell))
+
+    bulk = rescale_to_relaxed_bulk(bulk_supercell)
+    # relax bulk supercell positions in case it's only approximate (as it must be for different models), but stick
+    # to relaxed bulk's lattice constants as set by rescale_to_relaxed_bulk
+    bulk_supercell = relax_config(bulk_supercell, relax_pos=True, relax_cell=False, tol=tol, save_traj=True,
+        config_label="rescaled_bulk", from_base_model=True, save_config=True)
+
+    ase.io.write(os.path.join("..", run_root+"-rescaled-bulk.xyz"),  bulk_supercell, format='extxyz')
+
+    print("got bulk primitive cell ", bulk.get_cell())
+    print("got rescaled bulk_supercell cell ", bulk_supercell.get_cell())
+
+    if 'arb_supercell' in bulk_supercell.info:
+        print("making bulk supercell from", bulk_supercell.info['arb_supercell'].reshape((3,3)))
+        bulk_supersupercell = ase.build.make_supercell(bulk_supercell, bulk_supercell.info['arb_supercell'].reshape((3,3)))
+        print("got supersupercell with ", len(bulk_supersupercell), "atoms, cell\n", bulk_supersupercell.get_cell())
+
+        bulk_supersupercell.info.update(bulk_supercell.info)
+        bulk_supercell = bulk_supersupercell
+
+    sym_data = spglib.get_symmetry_dataset(bulk_supercell, symprec=0.01)
+    equiv_at = set([tuple(iZ) for iZ in zip(sym_data["equivalent_atoms"], bulk_supercell.numbers)])
+
+    # print("equiv_at", equiv_at)
+
+    antisite_list = []
+    for i1, Z1 in equiv_at:
+        for i2_proto, Z2 in equiv_at:
+            if Z1 <= Z2:
+                continue
+            # print("check i", i1, i2_proto, "Z", Z1, Z2)
+
+            i2s = np.where(sym_data["equivalent_atoms"] == i2_proto)[0]
+            i2_dists = bulk_supercell.get_distances(i1, i2s, mic=True)
+            farthest_ind = np.argmax(i2_dists)
+            i2 = i2s[farthest_ind]
+
+            antisite_list.append((i1, i2))
+
+    # print("antisite_list", antisite_list) ##
+
+    evaluate(bulk_supercell)
+    bulk_supercell_pe = bulk_supercell.get_potential_energy()
+    properties = { "bulk_struct_test" : bulk_supercell.info["bulk_struct_test"], "bulk_E_per_atom" : bulk_supercell_pe / len(bulk_supercell), "defects" : {} }
+
+    for i1, i2 in antisite_list:
+        (label, unrelaxed_filename, Ef0, relaxed_filename, Ef, Z1, Z2) = do_one_antisite_pair(bulk_supercell, bulk_supercell_pe, i1, i2, tol)
+
+        properties["defects"][label] = { 'Ef0' : Ef0, 'Ef' : Ef, 'unrelaxed_filename' : unrelaxed_filename, 'relaxed_filename' : relaxed_filename,
+            'atom_inds' : (int(i1), int(i2)), 'Zs' : (int(Z1), int(Z2)) }
+
+    print("returning properties", properties)
+    return properties

--- a/share/find_voids.py
+++ b/share/find_voids.py
@@ -1,0 +1,47 @@
+import numpy as np, scipy.spatial, spglib, ase
+
+def find_voids(at, transl_symprec=1.0e-1, symprec=1.0e-2):
+    # save original cell
+    cell_orig = at.get_cell()
+    reciprocal_cell_orig = at.get_reciprocal_cell()
+
+    # create supercell
+    at_sc = at * [3,3,3]
+    at_sc.set_positions(at_sc.get_positions()-np.sum(cell_orig,axis=0))
+
+    # calculate Voronoi tesselation
+    vor = scipy.spatial.Voronoi(at_sc.get_positions())
+
+    # list possible centers from Voronoi vertices that are close to original cell
+    possible_centers_lat = np.matmul(vor.vertices, reciprocal_cell_orig.T)
+    possible_indices = np.where(np.logical_and(np.all(possible_centers_lat >= -0.1, axis=1), np.all(possible_centers_lat < 1.1, axis = 1)))[0]
+
+    # create atoms object with supercell of all possible interstitial positions
+    vertices = vor.vertices[possible_indices]
+    at_w_interst = at.copy()
+    at_w_interst.extend(ase.Atoms('X{}'.format(len(possible_indices)), positions=vertices))
+
+    # eliminate duplicates that are equivalent by translation
+    dists = at_w_interst.get_all_distances(mic=True)
+    del_list = set()
+    for i in range(len(at_w_interst)-1):
+        dups = i+1 + np.where(dists[i][i+1:] < transl_symprec)[0]
+        del_list = del_list.union(set(dups))
+
+    del at_w_interst[list(del_list)]
+
+    dataset = spglib.get_symmetry_dataset(at_w_interst, symprec)
+    if dataset is not None:
+        equivalent_indices = set(dataset["equivalent_atoms"][len(at):])
+    else:
+        equivalent_indices = set(range(len(at)+1,len(at_w_interst)))
+
+    pos = at_w_interst.get_positions()
+    voids = []
+    for i in equivalent_indices:
+        at_t = at + ase.Atom('H')
+        p = at_t.get_positions(); p[-1] = pos[i]; at_t.set_positions(p)
+        d = min(at_t.get_distances(len(at_t)-1, range(len(at_t)-1), mic=True))
+        voids.append((d, pos[i][0], pos[i][1], pos[i][2]))
+
+    return sorted(voids, key = lambda x : x[0], reverse=True)

--- a/share/interstitial.py
+++ b/share/interstitial.py
@@ -5,7 +5,9 @@ from ase.neighborlist import NeighborList
 from ase.constraints import FixedPlane
 import numpy as np
 
-def do_one_interstitial(bulk_supercell, bulk_supercell_pe, interstitial_Z, interstitial_pos, relax_radial=0.0, relax_symm_break=0.0, nn_cutoff=0.0, tol=1.0e-2):
+from find_voids import find_voids
+
+def do_one_interstitial(bulk_supercell, bulk_supercell_pe, interstitial_Z, interstitial_pos, label, relax_radial=0.0, relax_symm_break=0.0, nn_cutoff=0.0, tol=1.0e-2):
 
     interst = bulk_supercell.copy()
     interst += Atoms(numbers=[interstitial_Z], positions=[interstitial_pos])
@@ -44,68 +46,84 @@ def do_one_interstitial(bulk_supercell, bulk_supercell_pe, interstitial_Z, inter
     evaluate(interst)
     unrelaxed_interstitial_pe = interst.get_potential_energy()
 
-    label = "Z_%d" % (interstitial_Z)
-    unrelaxed_filename=run_root+"-%s-unrelaxed.xyz" % label
-    ase.io.write(os.path.join("..",unrelaxed_filename),  interst, format='extxyz')
-    interst = relax_config(interst, relax_pos=True, relax_cell=False, tol=tol, traj_file=None, 
-        config_label=label, from_base_model=True, save_config=True)
-
-    relaxed_filename=run_root+"-%s-relaxed.xyz" % label
-    ase.io.write(os.path.join("..",relaxed_filename),  interst, format='extxyz')
-
-    interstitial_pe = interst.get_potential_energy()
     if len(set(bulk_supercell.get_atomic_numbers())) == 1:
         Ebulk = float(len(interst))/float(len(bulk_supercell)) * bulk_supercell_pe
     else:
         Ebulk = bulk_supercell_pe
     Ef0 = unrelaxed_interstitial_pe - Ebulk
-    Ef = interstitial_pe - Ebulk
-    print("got interstitial {} cell energy".format(label),interstitial_pe)
+
+    unrelaxed_filename=run_root+"-%s-unrelaxed.xyz" % label
+    ase.io.write(os.path.join("..",unrelaxed_filename),  interst, format='extxyz')
+
+    print("got unrelaxed interstitial {} cell energy".format(label), unrelaxed_interstitial_pe)
+
+    try:
+        interst = relax_config(interst, relax_pos=True, relax_cell=False, tol=tol, save_traj=True,
+            config_label=label, from_base_model=True, save_config=True, try_restart=True)
+
+        relaxed_filename=run_root+"-%s-relaxed.xyz" % label
+        ase.io.write(os.path.join("..",relaxed_filename),  interst, format='extxyz')
+
+        interstitial_pe = interst.get_potential_energy()
+        Ef = interstitial_pe - Ebulk
+
+        print("got relaxed interstitial {} cell energy".format(label), interstitial_pe)
+    except:
+        relaxed_filename = None
+        Ef = None
+
     print("got bulk energy", Ebulk)
-    return ( label, unrelaxed_filename, Ef0, relaxed_filename, Ef, interstitial_i)
+    return ( unrelaxed_filename, Ef0, relaxed_filename, Ef, interstitial_i)
 
 
-def do_interstitial(test_dir, nn_cutoff=0.0, tol=1.0e-2):
-    print("doing do_interstitial")
+def do_all_interstitials(test_dir, nn_cutoff=0.0, tol=1.0e-2):
+    print("doing do_all_interstitials")
     bulk_supercell = ase.io.read(os.path.join(test_dir,"bulk_supercell.xyz"), format="extxyz")
     print("got bulk_supercell ", len(bulk_supercell))
 
     bulk = rescale_to_relaxed_bulk(bulk_supercell)
-    # relax bulk supercell positions in case it's only approximate (as it must be for different models), but stick 
+    # relax bulk supercell positions in case it's only approximate (as it must be for different models), but stick
     # to relaxed bulk's lattice constants as set by rescale_to_relaxed_bulk
-    bulk_supercell = relax_config(bulk_supercell, relax_pos=True, relax_cell=False, tol=tol, traj_file=None, 
+    bulk_supercell = relax_config(bulk_supercell, relax_pos=True, relax_cell=False, tol=tol, save_traj=True,
         config_label="relaxed_bulk", from_base_model=True, save_config=True)
-
-    evaluate(bulk_supercell)
-    bulk_supercell_pe = bulk_supercell.get_potential_energy()
 
     ase.io.write(os.path.join("..",run_root+"-rescaled-bulk.xyz"),  bulk_supercell, format='extxyz')
 
     print("got bulk primitive cell ", bulk.get_cell())
     print("got rescaled bulk_supercell cell ", bulk_supercell.get_cell())
 
-    properties = { "bulk_struct_test" : bulk_supercell.info["bulk_struct_test"], "bulk_E_per_atom" : bulk_supercell_pe / len(bulk_supercell), "defects" : {} }
-
     try: # Cartesian 3-vector
-        interstitial_pos = np.array([float(x) for x in bulk_supercell.info["interstitial_position"]])
-        if len(interstitial_pos) != 3:
+        interstitial_pos_l = [ np.array([float(x) for x in bulk_supercell.info["interstitials"]]) ]
+        if len(interstitial_pos_l) != 3:
             raise ValueError("not a 3-vector")
     except:
-        interstitial_pos_type = bulk_supercell.info["interstitial_position"].split()[0]
+        interstitial_pos_type = bulk_supercell.info["interstitials"].split()[0]
         if interstitial_pos_type == "mean":
-            neighbor_indices = [int(i) for i in bulk_supercell.info["interstitial_position"].split()[1:]]
+            neighbor_indices = [int(i) for i in bulk_supercell.info["interstitials"].split()[1:]]
             if len(neighbor_indices) < 2:
                 raise ValueError("interstitial position type mean, but {} < 2 indices".format(len(neighbor_indices)))
-            interstitial_pos = np.sum(bulk_supercell.get_positions()[neighbor_indices],axis=0) / float(len(neighbor_indices))
+            interstitial_pos_l = [ np.sum(bulk_supercell.get_positions()[neighbor_indices],axis=0) / float(len(neighbor_indices)) ]
+        elif interstitial_pos_type == "inequivalent":
+            if 'arb_supercell' in bulk_supercell.info:
+                print("making bulk supercell from", bulk_supercell.info['arb_supercell'].reshape((3,3)) )
+                bulk_supersupercell = ase.build.make_supercell(bulk_supercell, bulk_supercell.info['arb_supercell'].reshape((3,3)) )
+                print("got supersupercell with ",len(bulk_supersupercell),"atoms, cell\n",bulk_supersupercell.get_cell())
+            voids = find_voids(bulk_supercell)
+            interstitial_pos_l = [ (v[1], v[2], v[3]) for v in voids ]
+
+            bulk_supersupercell.info.update(bulk_supercell.info)
+            bulk_supercell = bulk_supersupercell
         else:
-            raise ValueError("Unknown interstitial position type in '"+bulk_supercell.info["interstitial_position"]+"'")
+            raise ValueError("Unknown interstitial position type in '"+bulk_supercell.info["interstitials"]+"'")
 
-    if isinstance(bulk_supercell.info["Zs"],list):
-        Z_list = bulk_supercell.info["Zs"]
-    else:
-        Z_list = [ bulk_supercell.info["Zs"] ]
+    evaluate(bulk_supercell)
+    bulk_supercell_pe = bulk_supercell.get_potential_energy()
+    properties = { "bulk_struct_test" : bulk_supercell.info["bulk_struct_test"], "bulk_E_per_atom" : bulk_supercell_pe / len(bulk_supercell), "defects" : {} }
+
+    Z_list = ( [ bulk_supercell.info["Zs"] ] if isinstance(bulk_supercell.info["Zs"], (int, np.integer))
+                                             else bulk_supercell.info["Zs"] )
+
     for interstitial_Z in Z_list:
-
         try:
             relax_radial = bulk_supercell.info['relax_radial_{}'.format(interstitial_Z)]
         except:
@@ -115,10 +133,13 @@ def do_interstitial(test_dir, nn_cutoff=0.0, tol=1.0e-2):
         except:
             relax_symm_break = 0.0
 
-        (label, unrelaxed_filename, Ef0, relaxed_filename, Ef, interstitial_i) = do_one_interstitial(bulk_supercell, bulk_supercell_pe, interstitial_Z, interstitial_pos, relax_radial, relax_symm_break, nn_cutoff, tol)
+        for interst_i, interst_pos in enumerate(interstitial_pos_l):
+            label = f'Z_{interstitial_Z}_pos_{interst_i}'
+            (unrelaxed_filename, Ef0, relaxed_filename, Ef, interstitial_i) = do_one_interstitial(bulk_supercell, bulk_supercell_pe,
+                interstitial_Z, interst_pos, label, relax_radial, relax_symm_break, nn_cutoff, tol)
 
-    properties["defects"][label] = { 'Ef0' : Ef0, 'Ef' : Ef, 'unrelaxed_filename' : unrelaxed_filename, 'relaxed_filename' : relaxed_filename, 'atom_ind' : int(interstitial_i), 'Z' : int(interstitial_Z) }
-    if len(set(bulk_supercell.get_atomic_numbers())) != 1:
-        properties["defects"][label]['dmu'] = [-1, interstitial_Z]
+            properties["defects"][label] = { 'Ef0' : Ef0, 'Ef' : Ef, 'unrelaxed_filename' : unrelaxed_filename, 'relaxed_filename' : relaxed_filename, 'atom_ind' : int(interstitial_i), 'Z' : int(interstitial_Z), 'pos_index' : interst_i }
+            if len(set(bulk_supercell.get_atomic_numbers())) != 1:
+                properties["defects"][label]['dmu'] = [-1, int(interstitial_Z)]
 
     return properties

--- a/share/lattice.py
+++ b/share/lattice.py
@@ -39,7 +39,7 @@ def calc_E_vs_V(bulk, dV=0.025, n_steps=(-10,10), tol=1e-2, method='lbfgs'): # h
           if hasattr(model, "fix_cell_dependence"):
                model.fix_cell_dependence(scaled_bulk)
           ase.io.write(run_root+"-E_vs_V_%03d-unrelaxed.xyz" % i,  scaled_bulk, format='extxyz')
-          scaled_bulk = relax_config(scaled_bulk, relax_pos=True, relax_cell=True, tol=tol, max_steps=200, traj_file="E_vs_V_traj_%02d.extxyz" % i, constant_volume=True, method=method,
+          scaled_bulk = relax_config(scaled_bulk, relax_pos=True, relax_cell=True, tol=tol, max_steps=200, save_traj=True, constant_volume=True, method=method,
               refine_symmetry_tol=1.0e-1, keep_symmetry=True, config_label="E_vs_V_%03d" % i, from_base_model=True, save_config=True)
       except Exception as e:
           print("WARNING: failed config in calc_E_vs_V", str(e))
@@ -58,7 +58,7 @@ def calc_E_vs_V(bulk, dV=0.025, n_steps=(-10,10), tol=1e-2, method='lbfgs'): # h
           if hasattr(model, "fix_cell_dependence"):
                model.fix_cell_dependence(scaled_bulk)
           ase.io.write(run_root+"-E_vs_V_%02d-unrelaxed.xyz" % i,  scaled_bulk, format='extxyz')
-          scaled_bulk = relax_config(scaled_bulk, relax_pos=True, relax_cell=True, tol=tol, max_steps=200, traj_file="E_vs_V_traj_%02d.extxyz" % i, constant_volume=True, method=method,
+          scaled_bulk = relax_config(scaled_bulk, relax_pos=True, relax_cell=True, tol=tol, max_steps=200, save_traj=True, constant_volume=True, method=method,
               refine_symmetry_tol=1.0e-1, keep_symmetry=True, config_label="E_vs_V_%02d" % i, from_base_model=True, save_config=True)
       except Exception as e:
           print("failed", str(e))
@@ -86,7 +86,7 @@ def do_lattice(test_dir, lattice_type, dV=0.025, n_steps=(-10,10), tol=1.0e-2, m
        if hasattr(model, "fix_cell_dependence"):
            model.fix_cell_dependence(bulk)
        orig_cell = bulk.get_cell()
-       bulk = relax_config(bulk, relax_pos=True, relax_cell=True, tol=tol, traj_file="lattice_bulk_traj.xyz", method=method,
+       bulk = relax_config(bulk, relax_pos=True, relax_cell=True, tol=tol, save_traj=True, method=method,
                            refine_symmetry_tol=1.0e-2, keep_symmetry=True, config_label="bulk", from_base_model=True, save_config=True, applied_P=applied_P)
        new_cell = bulk.get_cell()
        if hasattr(model, "fix_cell_dependence"):

--- a/share/surface.py
+++ b/share/surface.py
@@ -24,7 +24,8 @@ def do_symmetric_surface(test_dir):
 
     # relax surface system
     tol = 1.0e-2
-    surf = relax_config(surf, relax_pos=True, relax_cell=False, tol=tol, traj_file=None, config_label="surface", from_base_model=True, save_config=True)
+    surf = relax_config(surf, relax_pos=True, relax_cell=False, tol=tol, save_traj=True,
+                        config_label="surface", from_base_model=True, save_config=True, try_restart=True)
 
     ase.io.write(os.path.join("..",run_root+"-relaxed.xyz"),  surf, format='extxyz')
 

--- a/share/vacancy.py
+++ b/share/vacancy.py
@@ -33,8 +33,8 @@ def do_one_vacancy(bulk_supercell, bulk_supercell_pe, vac_i, relax_radial=0.0, r
     del vac[vac_i]
     vac_pos = vac.positions[vac_i]
 
-    vac = relax_config(vac, relax_pos=True, relax_cell=False, tol=tol, traj_file=None,
-        config_label=label, from_base_model=True, save_config=True)
+    vac = relax_config(vac, relax_pos=True, relax_cell=False, tol=tol, save_traj=True,
+        config_label=label, from_base_model=True, save_config=True, try_restart=True)
     relaxed_filename=run_root+"-%s-relaxed.xyz" % label
     ase.io.write(os.path.join("..",relaxed_filename), vac, format='extxyz')
 
@@ -58,7 +58,7 @@ def do_all_vacancies(test_dir, nn_cutoff=0.0, tol=1.0e-2):
     bulk = rescale_to_relaxed_bulk(bulk_supercell)
     # relax bulk supercell positions in case it's only approximate (as it must be for different models), but stick
     # to relaxed bulk's lattice constants as set by rescale_to_relaxed_bulk
-    bulk_supercell = relax_config(bulk_supercell, relax_pos=True, relax_cell=False, tol=tol, traj_file=None,
+    bulk_supercell = relax_config(bulk_supercell, relax_pos=True, relax_cell=False, tol=tol, save_traj=True,
         config_label="rescaled_bulk", from_base_model=True, save_config=True)
 
     ase.io.write(os.path.join("..",run_root+"-rescaled-bulk.xyz"),  bulk_supercell, format='extxyz')
@@ -71,11 +71,8 @@ def do_all_vacancies(test_dir, nn_cutoff=0.0, tol=1.0e-2):
         prim_vacancy_list = np.unique(sym_data["equivalent_atoms"])
         print("orig cell vacancy_list", prim_vacancy_list)
         if 'arb_supercell' in bulk_supercell.info:
-            print("making bulk supercell from", [ bulk_supercell.info['arb_supercell'][0:3], bulk_supercell.info['arb_supercell'][3:6], bulk_supercell.info['arb_supercell'][6:9] ] )
-            bulk_supersupercell = ase.build.make_supercell(bulk_supercell,
-                [ bulk_supercell.info['arb_supercell'][0:3],
-                  bulk_supercell.info['arb_supercell'][3:6],
-                  bulk_supercell.info['arb_supercell'][6:9] ] )
+            print("making bulk supercell from", bulk_supercell.info['arb_supercell'].reshape((3,3)) )
+            bulk_supersupercell = ase.build.make_supercell(bulk_supercell,bulk_supercell.info['arb_supercell'].reshape((3,3)) )
             print("got supersupercell with ",len(bulk_supersupercell),"atoms, cell\n",bulk_supersupercell.get_cell())
             vacancy_list = []
             for i in prim_vacancy_list:


### PR DESCRIPTION
run-all.py supports multiple test sets and setting tests path.
Possible to set bugs host, num procs manually.
Antisite pair, all inequivalent intersitials, point defects.
Make script running test model and test paths equivalently.  Can now specify an arbitrary path (above the test_set component) for the tests.
Use subprocess.run in run-all.py instead of os.system.
Add try_restart to utilities.py relax_config(), and use it in point defect and surface tests.

closes #1
closes #4 